### PR TITLE
Fix duplicate checkbox ID issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -93,7 +93,9 @@ function generateID() {
   if (tasks.length == 0) {
     return `${idPrefix}0`;
   }
-  return idPrefix + tasks.length;
+  let lastTask = document.querySelector('#list > li:last-child > input');
+  let lastIDNum = Number(lastTask.id.replace(idPrefix, ''));
+  return idPrefix + (lastIDNum + 1);
 }
 
 function moveFocus(element) {


### PR DESCRIPTION
I've noticed that since the generateID() function generates ID numbers based on the number of items currently in the list, that you can generate tasks whose checkboxes have the same ID.
You can do this by adding multiple tasks, then deleting one or more tasks that aren't the last one, then adding more tasks.
This results in some labels being linked to the wrong checkbox and the incorrect checkbox being toggled when their label is clicked.
This issue has been fixed by making the generateID() function check the ID of the last task on the list and generate one that is one number higher.